### PR TITLE
Bump NNCF version to 3.2.0

### DIFF
--- a/src/nncf/version.py
+++ b/src/nncf/version.py
@@ -9,4 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"


### PR DESCRIPTION
This PR bumps the NNCF version to 3.2.0 on the develop branch.