### PR TITLE
Release notes for NNCF version 3.1.0

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,40 @@
 # Release Notes
 
+## New in Release 3.1.0
+
+Post-training Quantization:
+
+- Breaking changes:
+  - (Weight Compression) Removed the deprecated `int8` mode. Use `nncf.CompressWeightsMode.INT8_SYM` or `nncf.CompressWeightsMode.INT8_ASYM` instead.
+- Features:
+  - (OpenVINO) Added support for the NVFP4 compression data type in Weight Compression, enabling INT4-equivalent quantization using NVIDIA's FP4 format.
+  - Added `backup_mode` parameter to `nncf.compress_weights()` for FP compression formats, allowing users to specify a fallback compression mode for layers that cannot be compressed with the primary mode.
+  - Added a [GPTQModel convertor](tools/) tool that converts GPTQ-compressed models to NNCF format.
+- Fixes:
+  - (Weight Compression) Fixed wrong usage of `do_float_quantization` that could lead to incorrect compression results.
+  - (ONNX) Fixed `nncf.errors.ValidationError: There is no tensor with the name` error during model graph building.
+  - (OpenVINO) Fixed RoPe ignored pattern detection for cases where the transpose operation is absent.
+  - Fixed scale estimation for adaptive codebook compression.
+- Improvements:
+  - (PyTorch) Migrated from `torch.ao` to `torchao` for TorchAO backend integration.
+  - Migrated `NNCFGraph` internal representation from `nx.DiGraph` to `nx.MultiDiGraph`, enabling correct handling of graphs with multiple edges between the same pair of nodes.
+  - Removed redundant `get_raw_statistic_collector` backend methods.
+  - Added lazy import for `nncf.torch` to reduce startup time when the torch backend is not used.
+  - (PyTorch) Added `TopKMetatype` support for graph building.
+
+Deprecations/Removals:
+
+- (Weight Compression) Removed the deprecated `nncf.CompressWeightsMode.INT8` mode.
+
+Requirements:
+
+- Updated PyTorch to 2.10.0.
+- Updated `onnxruntime` from 1.21.1 to 1.24.3.
+- Updated `onnx` from 1.17.0 to 1.20.1.
+- Updated `numpy` minimum version.
+- Moved `pandas` to an optional dependency.
+- Removed unused `pillow` dependency from requirements files.
+
 ## New in Release 3.0.0
 
 Post-training Quantization:


### PR DESCRIPTION
This PR adds release notes for NNCF version 3.1.0.